### PR TITLE
Change around things for 'high-scores' solution

### DIFF
--- a/high-scores/src/lib.rs
+++ b/high-scores/src/lib.rs
@@ -23,6 +23,6 @@ impl<'a> HighScores<'a> {
     }
 
     pub fn personal_top_three(&self) -> Vec<u32> {
-        self.scores.iter().cloned().sorted().rev().take(3).collect()
+        self.scores.iter().sorted().rev().take(3).cloned().collect()
     }
 }

--- a/high-scores/src/lib.rs
+++ b/high-scores/src/lib.rs
@@ -15,11 +15,11 @@ impl<'a> HighScores<'a> {
     }
 
     pub fn latest(&self) -> Option<u32> {
-        self.scores.iter().cloned().last()
+        self.scores.last().cloned()
     }
 
     pub fn personal_best(&self) -> Option<u32> {
-        self.scores.iter().cloned().max()
+        self.scores.iter().max().cloned()
     }
 
     pub fn personal_top_three(&self) -> Vec<u32> {


### PR DESCRIPTION
This moves around the `cloned()` to the end of the statements, and removes a superfluous `iter()` for the latest high-score.